### PR TITLE
Add better indentation for single-line case statements

### DIFF
--- a/settings/language-cpp14.cson
+++ b/settings/language-cpp14.cson
@@ -2,5 +2,5 @@
   'editor':
     'commentStart': '// '
     'tabLength': 4
-    'increaseIndentPattern': '(?:\\{|:)$'
+    'increaseIndentPattern': '(?:\\{|:)$|(\\bcase\\b.*:.*|\\bdefault\\b:.*)$'
     'decreaseIndentPattern': '(?:^\\s*\\}|\\b(?:case\\b.*|default|private|protected|public):)'


### PR DESCRIPTION
Previously, when a switch block used single-line case statements,
the regex pattern for increasing indentation didn't include `case` or
`default` lines that didn't end in a colon. This caused following
lines to appear at the same indentation level which could, in turn,
cause `case` or `default` statements to misalign.

Example:

``` cpp
void foobar() {
    switch (val) {
    case foo:
    case bar: return 0;
default: return 1
    }
}
```

To fix this issue, the regex pattern `increaseIndentPattern` has been
expanded to cover these expressions.
